### PR TITLE
Pruebas unitarias de PurchaseDetail

### DIFF
--- a/Backend/InventoryManagement/InventoryManagement.Application.Tests/InventoryManagement.Application.Tests.csproj
+++ b/Backend/InventoryManagement/InventoryManagement.Application.Tests/InventoryManagement.Application.Tests.csproj
@@ -8,7 +8,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Backend/InventoryManagement/InventoryManagement.Application.Tests/PurchaseDetailControllerTest/PurchaseDetailControllerTest.cs
+++ b/Backend/InventoryManagement/InventoryManagement.Application.Tests/PurchaseDetailControllerTest/PurchaseDetailControllerTest.cs
@@ -1,0 +1,160 @@
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Xunit;
+using InventoryManagement.Application.Interfaces;
+using InventoryManagement.Controllers;
+using InventoryManagement.Domain.Entities;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using System;
+
+namespace InventoryManagement.Application.Tests.PurchaseDetails;
+
+public class PurchaseDetailsControllerTests
+{
+    private readonly Mock<IPurchaseDetailRepository> _mockRepo;
+    private readonly PurchaseDetailsController _controller;
+
+    public PurchaseDetailsControllerTests()
+    {
+        _mockRepo = new Mock<IPurchaseDetailRepository>();
+        _controller = new PurchaseDetailsController(_mockRepo.Object);
+    }
+    
+    // Helper que crea un objeto de prueba válido pero simple
+    private PurchaseDetail CreateSampleDetail()
+    {
+        return new PurchaseDetail
+        {
+            PurchaseId = 1,
+            ProductId = 101,
+            Quantity = 5,
+            UnitPrice = 10.0m,
+            // Se crean objetos mínimos solo para satisfacer las propiedades 'required'
+            Purchase = new Purchase { Supplier = new Supplier(), PurchaseDetails = new List<PurchaseDetail>() },
+            Product = new Product 
+                                { 
+                                    Name = "Sample Product",
+                                    // Dale un nombre a la categoría de ejemplo
+                                    Category = new Category { Name = "Sample Category" }, 
+                                    CategoryId = 1 
+                                }
+        };
+    }
+
+    [Fact]
+    public async Task GetAllPurchaseDetails_AsAdmin_ReturnsOkWithDetails()
+    {
+        var detailsList = new List<PurchaseDetail> { CreateSampleDetail() };
+        _mockRepo.Setup(r => r.GetAllAsync()).ReturnsAsync(detailsList);
+
+        var result = await _controller.GetAllPurchaseDetails("Admin");
+
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        var details = Assert.IsAssignableFrom<List<PurchaseDetail>>(okResult.Value);
+        Assert.Single(details);
+    }
+
+    [Fact]
+    public async Task GetAllPurchaseDetails_AsNonAdmin_ReturnsForbid()
+    {
+        var result = await _controller.GetAllPurchaseDetails("Employee");
+        Assert.IsType<ForbidResult>(result);
+    }
+
+    [Fact]
+    public async Task GetDetailsByPurchaseId_WhenDetailsExist_ReturnsOkWithDetails()
+    {
+        var purchaseId = 1;
+        var detailsList = new List<PurchaseDetail> { CreateSampleDetail() };
+        _mockRepo.Setup(r => r.GetByPurchaseIdAsync(purchaseId)).ReturnsAsync(detailsList);
+
+        var result = await _controller.GetDetailsByPurchaseId(purchaseId);
+
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        var details = Assert.IsAssignableFrom<List<PurchaseDetail>>(okResult.Value);
+        Assert.NotEmpty(details);
+    }
+
+    [Theory]
+    [InlineData(true)]  // Caso 1: El repositorio devuelve una lista vacía
+    [InlineData(false)] // Caso 2: El repositorio devuelve null
+    public async Task GetDetailsByPurchaseId_WhenDetailsDoNotExist_ReturnsNotFound(bool returnEmptyList)
+    {
+        var purchaseId = 99;
+        var repoResponse = returnEmptyList ? new List<PurchaseDetail>() : null;
+        _mockRepo.Setup(r => r.GetByPurchaseIdAsync(purchaseId)).ReturnsAsync(repoResponse!);
+
+        var result = await _controller.GetDetailsByPurchaseId(purchaseId);
+
+        Assert.IsType<NotFoundObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task AddPurchaseDetail_AsAdmin_ReturnsOk()
+    {
+        var newDetail = CreateSampleDetail();
+        
+        var result = await _controller.AddPurchaseDetail(newDetail, "Admin");
+        
+        Assert.IsType<OkObjectResult>(result);
+        _mockRepo.Verify(r => r.AddAsync(newDetail), Times.Once);
+    }
+
+    [Fact]
+    public async Task AddPurchaseDetail_AsNonAdmin_ReturnsForbid()
+    {
+        var newDetail = CreateSampleDetail();
+
+        var result = await _controller.AddPurchaseDetail(newDetail, "Employee");
+
+        Assert.IsType<ForbidResult>(result);
+        _mockRepo.Verify(r => r.AddAsync(It.IsAny<PurchaseDetail>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task AddPurchaseDetail_WhenRepositoryThrowsException_ReturnsInternalServerError()
+    {
+        var newDetail = CreateSampleDetail();
+        _mockRepo.Setup(r => r.AddAsync(It.IsAny<PurchaseDetail>())).ThrowsAsync(new Exception("Database error"));
+        
+        var result = await _controller.AddPurchaseDetail(newDetail, "Admin");
+        
+        var statusCodeResult = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(500, statusCodeResult.StatusCode);
+    }
+    
+    [Fact]
+    public async Task UpdatePurchaseDetail_AsAdmin_ReturnsOk()
+    {
+        var detailToUpdate = CreateSampleDetail();
+        
+        var result = await _controller.UpdatePurchaseDetail(detailToUpdate, "Admin");
+        
+        Assert.IsType<OkObjectResult>(result);
+        _mockRepo.Verify(r => r.UpdateAsync(detailToUpdate), Times.Once);
+    }
+
+    [Fact]
+    public async Task UpdatePurchaseDetail_AsNonAdmin_ReturnsForbid()
+    {
+        var detailToUpdate = CreateSampleDetail();
+        
+        var result = await _controller.UpdatePurchaseDetail(detailToUpdate, "Employee");
+        
+        Assert.IsType<ForbidResult>(result);
+        _mockRepo.Verify(r => r.UpdateAsync(It.IsAny<PurchaseDetail>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task UpdatePurchaseDetail_WhenRepositoryThrowsException_ReturnsInternalServerError()
+    {
+        var detailToUpdate = CreateSampleDetail();
+        _mockRepo.Setup(r => r.UpdateAsync(It.IsAny<PurchaseDetail>())).ThrowsAsync(new Exception("Database error"));
+        
+        var result = await _controller.UpdatePurchaseDetail(detailToUpdate, "Admin");
+        
+        var statusCodeResult = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(500, statusCodeResult.StatusCode);
+    }
+}

--- a/Backend/InventoryManagement/InventoryManagement.Application.Tests/Purchases/PurchaseControllerTests.cs
+++ b/Backend/InventoryManagement/InventoryManagement.Application.Tests/Purchases/PurchaseControllerTests.cs
@@ -1,0 +1,191 @@
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Xunit;
+using InventoryManagement.Application.DTOs;
+using InventoryManagement.Application.Interfaces;
+using InventoryManagement.Controllers;
+using InventoryManagement.Domain.Entities;
+using System.Globalization;
+
+namespace InventoryManagement.Application.Tests.Purchases;
+
+public class PurchasesControllerTests
+{
+    private readonly Mock<IPurchaseRepository> _mockRepo;
+    private readonly PurchasesController _controller;
+
+    public PurchasesControllerTests()
+    {
+        _mockRepo = new Mock<IPurchaseRepository>();
+        _controller = new PurchasesController(_mockRepo.Object);
+    }
+
+    private Purchase GetSamplePurchase()
+    {
+        var supplier = new Supplier { Id = 1, Name = "TechCorp" };
+        var category = new Category { Id = 1, Name = "Laptops" };
+        var product = new Product { Id = 101, Name = "Laptop Gamer", CategoryId = 1, Category = category };
+
+        var purchase = new Purchase
+        {
+            Id = 1,
+            SupplierId = supplier.Id,
+            Supplier = supplier,
+            TotalPurchase = 1500,
+            CreationDate = DateTime.UtcNow,
+            CreatedByUserId = 4,
+            PurchaseDetails = new List<PurchaseDetail>()
+        };
+
+        var purchaseDetail = new PurchaseDetail { Purchase = purchase, Product = product, Quantity = 1, UnitPrice = 1500 };
+        purchase.PurchaseDetails.Add(purchaseDetail);
+        return purchase;
+    }
+
+    [Fact]
+    public async Task CreatePurchase_WhenCalled_ReturnsOk()
+    {
+        var purchaseDto = new CreatePurchaseDto { SupplierId = 1, PurchaseDetails = new List<CreatePurchaseDetailDto>() };
+        
+        var result = await _controller.CreatePurchase(purchaseDto, 4);
+
+        Assert.IsType<OkObjectResult>(result);
+        _mockRepo.Verify(r => r.AddAsync(purchaseDto, 4), Times.Once);
+    }
+
+    [Fact]
+    public async Task CreatePurchase_WhenRepositoryThrowsInvalidOperation_ReturnsBadRequest()
+    {
+        var purchaseDto = new CreatePurchaseDto { SupplierId = 1, PurchaseDetails = new List<CreatePurchaseDetailDto>() };
+        _mockRepo.Setup(r => r.AddAsync(It.IsAny<CreatePurchaseDto>(), It.IsAny<short>())).ThrowsAsync(new InvalidOperationException("Error de operación"));
+
+        var result = await _controller.CreatePurchase(purchaseDto, 4);
+
+        Assert.IsType<BadRequestObjectResult>(result);
+    }
+    
+    [Fact]
+    public async Task CreatePurchase_WhenRepositoryThrowsGenericException_ReturnsInternalServerError()
+    {
+        var purchaseDto = new CreatePurchaseDto { SupplierId = 1, PurchaseDetails = new List<CreatePurchaseDetailDto>() };
+        _mockRepo.Setup(r => r.AddAsync(It.IsAny<CreatePurchaseDto>(), It.IsAny<short>())).ThrowsAsync(new Exception("Error genérico"));
+
+        var result = await _controller.CreatePurchase(purchaseDto, 4);
+
+        var statusCodeResult = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(500, statusCodeResult.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetAllPurchases_AsAdmin_ReturnsOkWithMappedPurchases()
+    {
+        _mockRepo.Setup(r => r.GetAllAsync()).ReturnsAsync(new List<Purchase> { GetSamplePurchase() });
+
+        var result = await _controller.GetAllPurchases("Admin");
+
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        var response = Assert.IsAssignableFrom<List<PurchaseResponseDto>>(okResult.Value);
+        Assert.Single(response);
+        Assert.Equal("TechCorp", response[0].Proveedor);
+        Assert.Contains("BOB", response[0].Total);
+    }
+
+    [Theory]
+    [InlineData("Employee")]
+    [InlineData("Guest")]
+    public async Task GetAllPurchases_AsNonAdmin_ReturnsForbid(string role)
+    {
+        var result = await _controller.GetAllPurchases(role);
+
+        Assert.IsType<ForbidResult>(result);
+    }
+
+    [Fact]
+    public async Task GetUserPurchases_WhenCalled_ReturnsOkWithMappedPurchases()
+    {
+        _mockRepo.Setup(r => r.GetByUserIdAsync(4)).ReturnsAsync(new List<Purchase> { GetSamplePurchase() });
+        
+        var result = await _controller.GetUserPurchases(4);
+        
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        var response = Assert.IsAssignableFrom<List<PurchaseResponseDto>>(okResult.Value);
+        Assert.Single(response);
+    }
+
+    [Fact]
+    public async Task GetPurchaseById_WhenPurchaseNotFound_ReturnsNotFound()
+    {
+        _mockRepo.Setup(r => r.GetByIdAsync(99)).ReturnsAsync((Purchase?)null);
+
+        var result = await _controller.GetPurchaseById(99, 4, "Admin");
+
+        Assert.IsType<NotFoundObjectResult>(result);
+    }
+    
+    [Fact]
+    public async Task GetPurchaseById_AsOwner_ReturnsOk()
+    {
+        var samplePurchase = GetSamplePurchase(); // CreatedByUserId es 4
+        _mockRepo.Setup(r => r.GetByIdAsync(1)).ReturnsAsync(samplePurchase);
+        
+        var result = await _controller.GetPurchaseById(1, 4, "Employee");
+        
+        Assert.IsType<OkObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task GetPurchaseById_AsNonAdminAndNotOwner_ReturnsForbid()
+    {
+        var samplePurchase = GetSamplePurchase(); // CreatedByUserId es 4
+        _mockRepo.Setup(r => r.GetByIdAsync(1)).ReturnsAsync(samplePurchase);
+
+        var result = await _controller.GetPurchaseById(1, 99, "Employee");
+
+        Assert.IsType<ForbidResult>(result);
+    }
+    
+    [Fact]
+    public async Task UpdatePurchase_AsAdmin_ReturnsOk()
+    {
+        var samplePurchase = GetSamplePurchase();
+        _mockRepo.Setup(r => r.GetByIdAsync(1)).ReturnsAsync(samplePurchase);
+
+        var result = await _controller.UpdatePurchase(1, "Admin");
+
+        Assert.IsType<OkObjectResult>(result);
+        _mockRepo.Verify(r => r.UpdateAsync(samplePurchase), Times.Once);
+    }
+    
+    [Theory]
+    [InlineData("Employee")]
+    [InlineData("Guest")]
+    public async Task UpdatePurchase_AsNonAdmin_ReturnsForbid(string role)
+    {
+        var result = await _controller.UpdatePurchase(1, role);
+
+        Assert.IsType<ForbidResult>(result);
+    }
+
+    [Fact]
+    public async Task UpdatePurchase_WhenPurchaseNotFound_ReturnsNotFound()
+    {
+        _mockRepo.Setup(r => r.GetByIdAsync(99)).ReturnsAsync((Purchase?)null);
+        
+        var result = await _controller.UpdatePurchase(99, "Admin");
+        
+        Assert.IsType<NotFoundObjectResult>(result);
+    }
+    
+    [Fact]
+    public async Task UpdatePurchase_WhenRepositoryThrowsException_ReturnsInternalServerError()
+    {
+        var samplePurchase = GetSamplePurchase();
+        _mockRepo.Setup(r => r.GetByIdAsync(1)).ReturnsAsync(samplePurchase);
+        _mockRepo.Setup(r => r.UpdateAsync(It.IsAny<Purchase>())).ThrowsAsync(new Exception("Error de DB"));
+
+        var result = await _controller.UpdatePurchase(1, "Admin");
+
+        var statusCodeResult = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(500, statusCodeResult.StatusCode);
+    }
+}

--- a/Backend/InventoryManagement/InventoryManagement/Domain/Entities/PurchaseDetail.cs
+++ b/Backend/InventoryManagement/InventoryManagement/Domain/Entities/PurchaseDetail.cs
@@ -16,6 +16,6 @@ public class PurchaseDetail
     public decimal UnitPrice { get; set; }
 
     // Propiedades de navegación
-    public required virtual Purchase Purchase { get; set; }
-    public required virtual Product Product { get; set; }
+    public required virtual Purchase Purchase { get; set; } = null!;
+    public required virtual Product Product { get; set; } = null!;
 }


### PR DESCRIPTION
Se completo los test unitarios solicitados:
1. Supplier
2. Purchase
3. PurchaseDetail

La cobertura usando el coverlet sale:
<img width="2255" height="508" alt="image" src="https://github.com/user-attachments/assets/1f21dc12-4ddf-4447-886c-2b3b370af546" />

En el visual todos los test son exitosos usando dotnet test:
<img width="565" height="35" alt="image" src="https://github.com/user-attachments/assets/9030030d-d7e3-45c4-b1c7-751c87805b38" />

Y la cobertura de los archivos solicitados llegan al 100%:
<img width="418" height="875" alt="image" src="https://github.com/user-attachments/assets/fb2ff71a-1107-4f60-855d-de885b603377" />
